### PR TITLE
Fixing capacity plots

### DIFF
--- a/temoa-uiuc/data_parser.py
+++ b/temoa-uiuc/data_parser.py
@@ -15,7 +15,7 @@ plt.rcParams['font.family'] = "serif"
 
 
 variables = {'generation': 'V_FlowOut',
-             'capacity': 'V_Capacity',
+             'capacity': 'V_CapacityAvailableByPeriodAndTech',
              'emissions': 'V_EmissionActivityByPeriodAndProcess'}
 
 time_horizon = np.arange(2021, 2051, 1)
@@ -521,7 +521,7 @@ def parse_datalines(filepath):
     return lines
 
 
-def make_plots(data_paths, to_save):
+def make_plots(data_paths, to_save=True):
     """
     This function produces all plots and puts them in a folder
     called 'figure.'
@@ -531,6 +531,8 @@ def make_plots(data_paths, to_save):
     data_paths : list of strings
         This is the list of paths to input files that contain data
         from Temoa runs.
+    to_save: boolean
+        True if saving the figure is desired
     """
 
     plots_dict = {'emissions': emissions_plot,
@@ -600,7 +602,7 @@ def make_plots(data_paths, to_save):
     return
 
 
-def make_emissions_plots(data_paths, to_save):
+def make_emissions_plots(data_paths, to_save=True):
     """
     This function produces all plots and puts them in a folder
     called 'figure.'
@@ -610,6 +612,8 @@ def make_emissions_plots(data_paths, to_save):
     data_paths : list of strings
         This is the list of paths to input files that contain data
         from Temoa runs.
+    to_save: boolean
+        True if saving the figure is desired
     """
 
     plots_dict = {'emissions': emissions_plot,
@@ -645,7 +649,7 @@ def make_emissions_plots(data_paths, to_save):
     return
 
 
-def make_capacity_plots(data_paths, to_save):
+def make_capacity_plots(data_paths, to_save=True):
     """
     This function produces all plots and puts them in a folder
     called 'figure.'
@@ -655,6 +659,8 @@ def make_capacity_plots(data_paths, to_save):
     data_paths : list of strings
         This is the list of paths to input files that contain data
         from Temoa runs.
+    to_save: boolean
+        True if saving the figure is desired
     """
 
     plots_dict = {'emissions': emissions_plot,


### PR DESCRIPTION
Fixes #162.

The capacity plot for steam looks like this now:

![costScenario_ind_capacity](https://user-images.githubusercontent.com/43791150/109304421-064b9980-781b-11eb-8a01-98b1c7af7582.png)

